### PR TITLE
Refactor for past agenda

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,28 +22,50 @@ steps:
       $wikiTitle = $env:WIKI_TITLE
       $username = $env:WIKI_USER
       $password = $env:WIKI_PASSWORD
-      $forwardAgendaQuery = 'https://analytics.dev.azure.com/TBS-OCIO-ESP/gc-earb/_odata/v2.0/WorkItems?$select=Title,State&$filter=WorkItemType%20eq%20%27Meeting%27%20and%20State%20eq%20%27Committed%27&$expand=Children($select=Title,WorkItemType,Custom_Department,BacklogPriority,State)';
+      $forwardAgendaQuery = 'https://analytics.dev.azure.com/TBS-OCIO-ESP/_odata/v1.0/WorkItems?$select=WorkItemType,%20State,%20Title,%20Custom_Department,%20BacklogPriority&$expand=Iteration($select=IterationPath),%20Links($select=TargetWorkItem;%20$filter=(TargetWorkItem/Project/ProjectName%20eq%20%27gc-earb%27)%20and%20(LinkTypeReferenceName%20eq%20%27System.LinkTypes.Hierarchy-Forward%27);%20$expand=TargetWorkItem($select=WorkItemType,%20State,%20Title,%20Custom_Department,%20BacklogPriority;%20$expand=Iteration($select=IterationPath)))&$filter=(Project/ProjectName%20eq%20%27gc-earb%27%20AND%20WorkItemType%20eq%20%27Meeting%27%20AND%20(State%20eq%20%27Committed%27))%20and%20Links/any(l:%20(l/TargetWorkItem/Project/ProjectName%20eq%20%27gc-earb%27)%20and%20(l/LinkTypeReferenceName%20eq%20%27System.LinkTypes.Hierarchy-Forward%27))&$orderby=Iteration/IterationPath%20asc,%20WorkItemId%20asc';
 
-      function Get-QueryResultsTable($token, $backlogUrl)
+      function Get-QueryResultsTable($token, $odataQuery)
       {
           if ($null -eq $token) 
           {
-            throw('Missing token value')
+              throw('Missing token value')
           }
+
+          if ($null -eq $odataQuery) 
+          {
+              throw('Missing OData query')
+          }
+
           $authHeader = @{ 'Authorization' = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":" + $token)) }
-      
-          $result = Invoke-RestMethod -Method Get -Uri $backlogUrl -Headers $authHeader
-      
+
+          $result = Invoke-RestMethod -Method Get -Uri $odataQuery -Headers $authHeader
+
           $meetings = $result.value
-      
-          $wikicontent = "{{OCIO_GCEARB_Header}}`n<div style='color: black; padding: 3px; text-align:right; font: arial;'>This page was last updated on " + (Get-Date -format "yyyy/MM/dd HH:mm") + "</div>`n<div style='color: black; padding: 3px; text-align:right; font: arial;'>This page was originally generated in the ☁ via API</div>`n"
-      
+
+          $wikicontent = "{{OCIO_GCEARB_Header}}`n<multilang>`n"
+          $englishcontent = "@en|__NOTOC__`n<div style='color: black; padding: 3px; text-align:right; font: arial;'>This page was modified on " + (Get-Date -format "yyyy/MM/dd HH:mm") + "</div>`n"
+          $frenchcontent = "@fr|__NOTOC__`n<div style='color: black; padding: 3px; text-align:right; font: arial;'>Cette page a été modifiée le 2019-12-01 " + (Get-Date -format "yyyy/MM/dd HH:mm") + "</div>`n"
+          $frCulture = New-Object system.globalization.cultureinfo('fr-CA')
+
           foreach($meeting in $meetings)
-          { 
-              $wikicontent += "<h2>" + $meeting.Title + "</h2>`n<table class='wikitable sortable nowrap' style='width:100%'>";
-              $wikicontent += "`n<tr>`n<th>Item for Presentation</th>`n<th>Presenter</th>`n<th>Purpose</th>`n</tr>"
-      
-              $meetingItems = $meeting.Children | Sort-Object -Property BacklogPriority
+          {
+              $iteration = $meeting.Iteration.IterationPath.Split('\')[1]
+              $title = (Get-Date -Date "$iteration").ToString('D')
+              $titleFr = (Get-Date -Date "$iteration").ToString('D', $frCulture)
+              if ($meeting.State -eq 'Cancelled')
+              {
+                  $englishcontent += "<h2>" + $title + " - <span style='color:red;'>CANCELED</span></h2>`n<table class='wikitable sortable nowrap' style='width:100%'>";
+                  $frenchcontent += "<h2>" + $titleFr + " - <span style='color:red;'>ANNULÉ</span></h2>`n<table class='wikitable sortable nowrap' style='width:100%'>";
+              }
+              else
+              {
+                  $englishcontent += "<h2>" + $title + "</h2>`n<table class='wikitable sortable nowrap' style='width:100%'>";
+                  $frenchcontent += "<h2>" + $titleFr + "</h2>`n<table class='wikitable sortable nowrap' style='width:100%'>";
+              }
+              $englishcontent += "`n<tr>`n<th>Item for Presentation</th>`n<th>Presenter</th>`n<th>Purpose</th>`n</tr>"
+              $frenchcontent += "`n<tr>`n<th>Points présentés</th>`n<th>Présentateur</th>`n<th>Objet</th>`n</tr>"
+
+              $meetingItems = $meeting.Links.TargetWorkItem | Sort-Object -Property BacklogPriority
 
               # Go over children
               foreach($meetingItem in $meetingItems)
@@ -52,12 +74,31 @@ steps:
                   {
                       continue
                   }
+                  $englishcontent += "`n<tr>`n<td style='width:50%'>" + $meetingItem.Title + "</td>`n<td style='width:25%'>" + $meetingItem.Custom_Department + "</td>`n<td style='width:25%'>" + $meetingItem.WorkItemType + "</td>`n</tr>"
+                  
+                  if ($meetingItem.WorkItemType -eq 'Endorsement')
+                  {
+                      $purpose = 'Approbation'
+                  
+                  }
+                  elseif ($meetingItem.WorkItemType -eq 'Consent')
+                  {
+                      $purpose = 'Consentement'
+                  }
+                  else
+                  {
+                      $purpose = $meetingItem.WorkItemType
+                  }
 
-                  $wikicontent += "`n<tr>`n<td style='width:50%'>" + $meetingItem.Title + "</td>`n<td style='width:25%'>" + $meetingItem.Custom_Department + "</td>`n<td style='width:25%'>" + $meetingItem.WorkItemType + "</td>`n</tr>"
+                  $frenchcontent += "`n<tr>`n<td style='width:50%'>" + $meetingItem.Title + "</td>`n<td style='width:25%'>" + $meetingItem.Custom_Department + "</td>`n<td style='width:25%'>" + $purpose + "</td>`n</tr>"
               }
-      
-              $wikicontent += "`n</table>`n<br/>`n"
+
+              $englishcontent += "`n</table>`n<br/>`n"
+              $frenchcontent += "`n</table>`n<br/>`n"
           }
+          $wikicontent += $englishcontent
+          $wikicontent += $frenchcontent
+          $wikicontent += "`n</multilang>`n{{OCIO_GCEARB_Footer}}"
           return $wikicontent
       }
       

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,15 +22,15 @@ steps:
       $wikiTitle = $env:WIKI_TITLE
       $username = $env:WIKI_USER
       $password = $env:WIKI_PASSWORD
+      $forwardAgendaQuery = 'https://analytics.dev.azure.com/TBS-OCIO-ESP/gc-earb/_odata/v2.0/WorkItems?$select=Title,State&$filter=WorkItemType%20eq%20%27Meeting%27%20and%20State%20eq%20%27Committed%27&$expand=Children($select=Title,WorkItemType,Custom_Department,BacklogPriority,State)';
 
-      function Get-QueryResultsTable($token)
+      function Get-QueryResultsTable($token, $backlogUrl)
       {
           if ($null -eq $token) 
           {
             throw('Missing token value')
           }
           $authHeader = @{ 'Authorization' = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":" + $token)) }
-          $backlogUrl = 'https://analytics.dev.azure.com/TBS-OCIO-ESP/gc-earb/_odata/v2.0/WorkItems?$select=Title,State&$filter=WorkItemType%20eq%20%27Meeting%27%20and%20State%20eq%20%27Committed%27&$expand=Children($select=Title,WorkItemType,Custom_Department,BacklogPriority,State)';
       
           $result = Invoke-RestMethod -Method Get -Uri $backlogUrl -Headers $authHeader
       
@@ -215,6 +215,6 @@ steps:
           }
       }
       
-      Edit-Page $wikiTitle (Get-QueryResultsTable $env:ADO_TOKEN)
+      Edit-Page $wikiTitle (Get-QueryResultsTable $env:ADO_TOKEN $forwardAgendaQuery)
       
       Invoke-Logout


### PR DESCRIPTION
When looking at the Past Agenda, I noticed that we lost the multilingual aspect with our generation.
This adds back basic french layout for titles and table columns. Does not include Department codes right now.